### PR TITLE
add static method aliases in TestHttpServers, + update jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,9 +1961,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
           "dev": true
         }
       }
@@ -2116,9 +2116,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
       "dev": true
     },
     "babel-jest": {
@@ -4521,13 +4521,13 @@
       }
     },
     "jest": {
-      "version": "24.7.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.7.1.tgz",
-      "integrity": "sha512-AbvRar5r++izmqo5gdbAjTeA6uNRGoNRuj5vHB0OnDXo2DXWZJVuaObiGgtlvhKb+cWy2oYbQSfxv7Q7GjnAtA==",
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+      "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
       "dev": true,
       "requires": {
         "import-local": "^2.0.0",
-        "jest-cli": "^24.7.1"
+        "jest-cli": "^24.9.0"
       },
       "dependencies": {
         "jest-cli": {
@@ -6971,9 +6971,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
+      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-jest": "^24.7.1",
     "eslint": "^6.5.1",
     "eslint-formatter-pretty": "^2.1.1",
-    "jest": "^24.7.1",
+    "jest": "^24.9.0",
     "jest-junit": "^6.3.0",
     "ts-jest": "^24.1.0",
     "tslint": "^5.20.1",

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -77,6 +77,9 @@ export class TestHttpServer {
   /**
    * Creates and starts a [[TestHttpServer]] instance.
    *
+   * Note: in a non-TypeScript project that uses a transpiler, you may not be able to access this
+   * static method; if so, use the same method in [[TestHttpServers]] instead.
+   *
    * @param options
    *   Any desired [[http.ServerOptions]].
    */
@@ -88,6 +91,9 @@ export class TestHttpServer {
 
   /**
    * Creates and starts a [[TestHttpServer]] instance that uses HTTPS, with a self-signed certificate.
+   *
+   * Note: in a non-TypeScript project that uses a transpiler, you may not be able to access this
+   * static method; if so, use the same method in [[TestHttpServers]] instead.
    *
    * @param options
    *   Any desired [[https.ServerOptions]] other than the certificate.
@@ -268,6 +274,36 @@ export class TestHttpServer {
         }
       }
     }
+  }
+}
+
+/**
+ * Abstract class that provides the same static factory methods as [[TestHttpServer]].
+ * 
+ * This is provided only because some JavaScript projects may have difficulty importing a class that
+ * has both a constructor and static methods (transpilers may copy the import in a way that preserves
+ * only the constructor function and not the static members). `TestHttpServers.start()` is exactly
+ * equivalent to `TestHttpServer.start()`.
+ */
+export abstract class TestHttpServers {
+  /**
+   * Creates and starts a [[TestHttpServer]] instance.
+   *
+   * @param options
+   *   Any desired [[http.ServerOptions]].
+   */
+  public static async start(options?: http.ServerOptions): Promise<TestHttpServer> {
+    return await TestHttpServer.start(options);
+  }
+
+  /**
+   * Creates and starts a [[TestHttpServer]] instance that uses HTTPS, with a self-signed certificate.
+   *
+   * @param options
+   *   Any desired [[https.ServerOptions]] other than the certificate.
+   */
+  public static async startSecure(options?: https.ServerOptions): Promise<TestHttpServer> {
+    return await TestHttpServer.startSecure(options);
   }
 }
 

--- a/src/httpserver.ts
+++ b/src/httpserver.ts
@@ -279,7 +279,7 @@ export class TestHttpServer {
 
 /**
  * Abstract class that provides the same static factory methods as [[TestHttpServer]].
- * 
+ *
  * This is provided only because some JavaScript projects may have difficulty importing a class that
  * has both a constructor and static methods (transpilers may copy the import in a way that preserves
  * only the constructor function and not the static members). `TestHttpServers.start()` is exactly

--- a/test/httpserver-test.ts
+++ b/test/httpserver-test.ts
@@ -2,6 +2,7 @@ import {
   SSEItem,
   TestHttpHandlers,
   TestHttpServer,
+  TestHttpServers,
 } from "../src";
 
 import {
@@ -102,6 +103,9 @@ describe("TestHttpServer", () => {
       expect(req.path).toEqual("/thing");
       expect(req.body).toEqual("this is the content");
     }));
+
+  it("can be created via TestHttpServers alias", async () =>
+    withCloseable(async () => await TestHttpServers.start(), async (server) => undefined));
 });
 
 describe("TestHttpHandlers", () => {
@@ -180,4 +184,7 @@ describe("secure server", () => {
       const res = await promisifySingle(https.get)({ ...reqProps, ca: server.certificate });
       expect(res.statusCode).toBe(200);
     }));
+
+  it("can be created via TestHttpServers alias", async () =>
+    withCloseable(async () => await TestHttpServers.startSecure(), async (server) => undefined));
 });


### PR DESCRIPTION
I found that in a plain JS project that uses Babel for test code, the static methods in `TestHttpServer` were not available— only the class constructor. I _think_ this is because the transpiler is copying the imports in such a way that when it sees a function (the constructor), it does not expect the function to also have properties, and the properties are somehow lost; I remember something similar happening with the EventSource polyfill. However, a different JS project with basically the same configuration had no problem with this, so I'm not 100% sure what's going on.

In any case, my workaround is to add a class `TestHttpServers` (note trailing `s`) that contains only the static methods from `TestHttpServer`. I left them in the old location too, so it's not a breaking change.

If there's a better way to fix this, I'd love to know about it.