### PR TITLE
add async lock helper for test serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "tsc",
-    "test": "jest --ci --forceExit test",
+    "test": "jest --ci --forceExit",
     "lint": "tslint -c tslint.json 'src/**/*.ts' 'test/**/*.ts'"
   },
   "repository": {

--- a/src/async.ts
+++ b/src/async.ts
@@ -355,13 +355,17 @@ export class AsyncMutex {
    */
   public release(): void {
     if (this.held) {
-      setTimeout(() => {
-        const pvc = this.awaiters.pop();
-        if (this.awaiters.length === 0) {
-          this.held = false;
-        }
-        pvc.callback(null);
-      }, 0);
+      if (this.awaiters.length) {
+        setTimeout(() => {
+          const pvc = this.awaiters.pop();
+          if (this.awaiters.length === 0) {
+            this.held = false;
+          }
+          pvc.callback(null);
+        }, 0);
+      } else {
+        this.held = false;
+      }
     }
   }
 

--- a/src/async.ts
+++ b/src/async.ts
@@ -322,3 +322,60 @@ export class AsyncQueue<T> {
     this.closed = true;
   }
 }
+
+/**
+ * A simple asynchronous lock that can be held by one task at a time.
+ *
+ * This is a naive implementation that is meant for simple cases where two pieces of async test
+ * logic must not be run in parallel because they use the same resource.
+ */
+export class AsyncMutex {
+  private held: boolean;
+  private awaiters: Array<PromiseAndValueCallback<null>>;
+
+  public constructor() {
+    this.held = false;
+    this.awaiters = [];
+  }
+
+  public async acquire(): Promise<void> {
+    if (!this.held) {
+      this.held = true;
+      return Promise.resolve();
+    }
+    const pvc = new PromiseAndValueCallback<null>();
+    this.awaiters.push(pvc);
+    return pvc.promise;
+  }
+
+  /**
+   * Releases the lock. If someone else was waiting on an [[acquire]], they will now acquire it
+   * (first come first served). This simple implementation does not verify that you were the
+   * one who had actually acquired the lock.
+   */
+  public release(): void {
+    if (this.held) {
+      setTimeout(() => {
+        const pvc = this.awaiters.pop();
+        if (this.awaiters.length === 0) {
+          this.held = false;
+        }
+        pvc.callback(null);
+      }, 0);
+    }
+  }
+
+  /**
+   * Acquires the lock, awaits an asynchronous action, and ensures that the lock is released.
+   * @param action an asynchronous function
+   * @returns the function's return value.
+   */
+  public async do<T>(action: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await action();
+    } finally {
+      this.release();
+    }
+  }
+}


### PR DESCRIPTION
Background: jest's behavior with async tests is that tests that are all in the same file will be run serially, but tests in different files can be interleaved. That's fine if each test has isolated state, but in certain cases it's hard to keep the state isolated.[1]

So, we want the equivalent of a mutex or semaphore. There are open-source implementations of that, like [async-mutex](https://www.npmjs.com/package/async-mutex), but it's helpful to have a simple one here that doesn't rely on an additional dependency.[2]

[1] The immediate use case is in our SDK database integrations, where the tests are all hitting the same server. We could use a different key prefix for each test to keep the data from overlapping— except that ideally we should also do a test run where the key prefix is always empty, to make sure the default behavior is correct.

[2] Again, this is especially true because of the way our database integrations are tested. The tests in each add-on project will call back to shared test code in the main SDK project, and that test code can't rely on any devDependencies that are not in the add-on project; but we can assume that they all have launchdarkly-js-test-helpers.