### PR TITLE
update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
           run-lint: true
       - build-test-linux:
           name: oldest supported Node version
-          docker-image: circleci/node:6
+          docker-image: cimg/node:12.22
           run-lint: false
 
 jobs:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,7 @@
 node_modules/
+dist/
 docs/
 test-types.js
 test/
 test.js
+.eslintrc.js

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jest-junit": "^12.2.0",
     "ts-jest": "^27.0.5",
     "tunnel": "^0.0.6",
-    "typescript": "^3.8.3"
+    "typescript": "^4.3.5"
   },
   "jest": {
     "rootDir": ".",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepublish": "npm run build",
     "build": "tsc",
     "test": "jest --ci --forceExit",
-    "lint": "tslint -c tslint.json 'src/**/*.ts' 'test/**/*.ts'"
+    "lint": "eslint --format 'node_modules/eslint-formatter-pretty' --ignore-path .eslintignore ."
   },
   "repository": {
     "type": "git",
@@ -27,24 +27,23 @@
   },
   "homepage": "https://github.com/launchdarkly/js-test-helpers",
   "dependencies": {
-    "@babel/core": "^7.6.4",
-    "@babel/preset-env": "^7.6.3",
-    "@babel/runtime": "^7.6.3",
-    "@types/node": "^12.12.11",
-    "selfsigned": "^1.10.4"
+    "selfsigned": "^1.10.11"
   },
   "engines": {
     "node": ">= 0.6.x"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.23",
-    "babel-jest": "^24.7.1",
-    "eslint": "^6.5.1",
-    "eslint-formatter-pretty": "^2.1.1",
-    "jest": "^24.9.0",
-    "jest-junit": "^6.3.0",
-    "ts-jest": "^24.1.0",
-    "tslint": "^5.20.1",
+    "@babel/core": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
+    "@babel/runtime": "7.6.3",
+    "@types/jest": "^27.0.1",
+    "@types/node": "^12.12.11",
+    "babel-jest": "^27.0.2",
+    "eslint": "^7.32.0",
+    "eslint-formatter-pretty": "^4.1.0",
+    "jest": "^27.0.6",
+    "jest-junit": "^12.2.0",
+    "ts-jest": "^27.0.5",
     "tunnel": "^0.0.6",
     "typescript": "^3.8.3"
   },


### PR DESCRIPTION
* Update various development dependencies to newer versions.
* Move some packages that were incorrectly in `dependencies` to `devDependencies`.
* Update the version of `selfsigned`, which had a vulnerability warning that would also show up in any package that used `launchdarkly-js-test-helpers` for its tests.
* Update minimum Node.js version to 12. (As this is technically a breaking change, the next `launchdarkly-js-test-helpers` release will be 2.0.0)