### PR TITLE
update selfsigned dependency to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/launchdarkly/js-test-helpers",
   "dependencies": {
-    "selfsigned": "^1.10.11"
+    "selfsigned": "^2.0.1"
   },
   "engines": {
     "node": ">= 0.6.x"


### PR DESCRIPTION
This package is used to create self-signed certificates for our HTTPS-related unit tests. We're using an old version with a transitive dependency that causes [vulnerability warnings](https://app.circleci.com/pipelines/github/launchdarkly/js-test-helpers/91/workflows/36b39934-cef3-4da0-b475-c41564d7911c/jobs/156).